### PR TITLE
Switch to new recommended syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
   "keywords": ["laravel", "framework", "UPS", "Laravel UPS Api", "Laravel-Ups-Api", "Pierre Tondereau", "Ptondereau"],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/contracts": "5.1.*|5.2.*",
-    "illuminate/support": "5.1.*|5.2.*",
+    "illuminate/contracts": "5.1.* || 5.2.*",
+    "illuminate/support": "5.1.* || 5.2.*",
     "gabrielbull/ups-api": "^0.7.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8|^5.0",
+    "phpunit/phpunit": "^4.8 || ^5.0",
     "graham-campbell/testbench": "^3.1",
     "codeclimate/php-test-reporter": "^0.3.0"
   },


### PR DESCRIPTION
Composer now recommends using the double `||` instead of a single `|`.