### PR TITLE
Add sandbox mode and Shipping class

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can register the all or some Ups facade in the `aliases` key of your `config
 * `'UPSTimeInTransit' => 'Ptondereau\LaravelUpsApi\Facades\UpsTimeInTransit'`
 * `'UPSTracking' => 'Ptondereau\LaravelUpsApi\Facades\UpsTracking'`
 * `'UPSTradeability' => 'Ptondereau\LaravelUpsApi\Facades\UpsTradeability'`
+* `'UPSShipping' => 'Ptondereau\LaravelUpsApi\Facades\UpsShipping'`
+
 
 
 ## Configuration
@@ -67,6 +69,7 @@ You also need to add env variables into your .env with your credentials:
 UPS_ACCESS_KEY=key
 UPS_USER_ID=userId
 UPS_PASSWORD=password
+UPS_SANDBOX=true
 ```
 
 ## Usage

--- a/config/ups.php
+++ b/config/ups.php
@@ -14,4 +14,5 @@ return [
     'access_key' => env('UPS_ACCESS_KEY', 'test'),
     'user_id'    => env('UPS_USER_ID', 'test'),
     'password'   => env('UPS_PASSWORD', 'test'),
+    'sandbox'   => env('UPS_SANDBOX', 'true') == 'true',
 ];

--- a/config/ups.php
+++ b/config/ups.php
@@ -14,5 +14,5 @@ return [
     'access_key' => env('UPS_ACCESS_KEY', 'test'),
     'user_id'    => env('UPS_USER_ID', 'test'),
     'password'   => env('UPS_PASSWORD', 'test'),
-    'sandbox'   => env('UPS_SANDBOX', 'true') == 'true',
+    'sandbox'    => env('UPS_SANDBOX', true),
 ];

--- a/src/Facades/UpsShipping.php
+++ b/src/Facades/UpsShipping.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ptondereau\LaravelUpsApi\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * This is the Tradeability facade class.
+ *
+ * @author Pierre Tondereau <pierre@doers.fr>
+ */
+class UpsShipping extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'ups.shipping';
+    }
+}

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -76,10 +76,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new AddressValidation(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -95,10 +95,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new QuantumView(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -114,10 +114,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Tracking(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -133,10 +133,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Rate(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -152,10 +152,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new TimeInTransit(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -171,10 +171,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Locator(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -190,10 +190,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Tradeability(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }
@@ -209,10 +209,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Shipping(
-                $config['access_key'],
-                $config['user_id'],
-                $config['password'],
-                $config['sandbox']
+            $config['access_key'],
+            $config['user_id'],
+            $config['password'],
+            $config['sandbox']
             );
         });
     }

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -13,6 +13,7 @@ use Ups\Rate;
 use Ups\TimeInTransit;
 use Ups\Tracking;
 use Ups\Tradeability;
+use Ups\Shipping;
 
 /**
  * This is the Ups Api service provider class.
@@ -45,6 +46,7 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->registerTimeInTransit();
         $this->registerLocator();
         $this->registerTradeability();
+        $this->registerShipping();
     }
 
     /**
@@ -190,6 +192,24 @@ class UpsApiServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the Tradeability class.
+     *
+     * @return void
+     */
+    protected function registerShipping()
+    {
+        $this->app->singleton('ups.shipping', function (Container $app) {
+            $config = $app->config->get('ups');
+
+            return new Shipping(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
+        });
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return string[]
@@ -204,6 +224,7 @@ class UpsApiServiceProvider extends ServiceProvider
             'ups.time-in-transit',
             'ups.locator',
             'ups.tradeability',
+            'ups.shipping',
         ];
     }
 }

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -79,7 +79,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -97,7 +98,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -115,7 +117,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -133,7 +136,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -151,7 +155,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -169,7 +174,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -187,7 +193,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 
@@ -205,7 +212,8 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
-                $config['sandbox']);
+                $config['sandbox']
+            );
         });
     }
 

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -76,10 +76,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new AddressValidation(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -95,10 +95,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new QuantumView(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -114,10 +114,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Tracking(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -133,10 +133,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Rate(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -152,10 +152,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new TimeInTransit(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -171,10 +171,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Locator(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -190,10 +190,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Tradeability(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }
@@ -209,10 +209,10 @@ class UpsApiServiceProvider extends ServiceProvider
             $config = $app->config->get('ups');
 
             return new Shipping(
-            $config['access_key'],
-            $config['user_id'],
-            $config['password'],
-            $config['sandbox']
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']
             );
         });
     }

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -73,7 +73,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.address-validation', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new AddressValidation($config['access_key'], $config['user_id'], $config['password']);
+            return new AddressValidation(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -87,7 +91,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.quantum-view', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new QuantumView($config['access_key'], $config['user_id'], $config['password']);
+            return new QuantumView(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -101,7 +109,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.tracking', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new Tracking($config['access_key'], $config['user_id'], $config['password']);
+            return new Tracking(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -115,7 +127,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.rate', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new Rate($config['access_key'], $config['user_id'], $config['password']);
+            return new Rate(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -129,7 +145,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.time-in-transit', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new TimeInTransit($config['access_key'], $config['user_id'], $config['password']);
+            return new TimeInTransit(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -143,7 +163,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.locator', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new Locator($config['access_key'], $config['user_id'], $config['password']);
+            return new Locator(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 
@@ -157,7 +181,11 @@ class UpsApiServiceProvider extends ServiceProvider
         $this->app->singleton('ups.tradeability', function (Container $app) {
             $config = $app->config->get('ups');
 
-            return new Tradeability($config['access_key'], $config['user_id'], $config['password']);
+            return new Tradeability(
+                $config['access_key'],
+                $config['user_id'],
+                $config['password'],
+                $config['sandbox']);
         });
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -25,4 +25,9 @@ class ConfigTest extends TestCase
     {
         $this->assertEquals(Config::get('ups.password'), 'test');
     }
+
+    public function testSandboxConfig()
+    {
+        $this->assertTrue(Config::get('ups.sandbox'));
+    }
 }

--- a/tests/Facades/UpsShippingTest.php
+++ b/tests/Facades/UpsShippingTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Ptondereau\Tests\LaravelUpsApi\Facades;
+
+use GrahamCampbell\TestBenchCore\FacadeTrait;
+use Ptondereau\LaravelUpsApi\Facades\UpsShipping;
+use Ptondereau\Tests\LaravelUpsApi\TestCase;
+use Ups\Shipping;
+
+/**
+ * This is the UpsTradeabilityTest facade test class.
+ *
+ * @author Pierre Tondereau <pierre@doers.fr>
+ */
+class UpsShippingTest extends TestCase
+{
+    use FacadeTrait;
+
+    /**
+     * Get the facade accessor.
+     *
+     * @return string
+     */
+    protected function getFacadeAccessor()
+    {
+        return 'ups.shipping';
+    }
+
+    /**
+     * Get the facade class.
+     *
+     * @return string
+     */
+    protected function getFacadeClass()
+    {
+        return UpsShipping::class;
+    }
+
+    /**
+     * Get the facade root.
+     *
+     * @return string
+     */
+    protected function getFacadeRoot()
+    {
+        return Shipping::class;
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -10,6 +10,7 @@ use Ups\Rate;
 use Ups\TimeInTransit;
 use Ups\Tracking;
 use Ups\Tradeability;
+use Ups\Shipping;
 
 /**
  * This is the service provider test class.
@@ -53,5 +54,10 @@ class ServiceProviderTest extends TestCase
     public function testTradeabilityIsInjectable()
     {
         $this->assertIsInjectable(Tradeability::class);
+    }
+
+    public function testShippingIsInjectable()
+    {
+        $this->assertIsInjectable(Shipping::class);
     }
 }


### PR DESCRIPTION
Added UPS_SANDBOX to env variables that will be passed to UPS classes constructor as 4th parameter. It allows to test UPS integration before go to production. 
Sandbox mode is especially important for Shipping class that allows create shipments and print labels, because this operation require payments in production environment.
Minor code refactoring done in provider class because lines with 4 params were too long