### PR TITLE
Add support for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - env:
       - PHP_VERSION=7.2
       - LARAVEL_VERSION=^7.0
-      - SYMFONY_VERSION=^5.0
+      - SYMFONY_VERSION=^4.0
       - PHPUNIT_VERSION=^8.0
     - env:
       - PHP_VERSION=7.3
@@ -80,7 +80,7 @@ matrix:
     - env:
       - PHP_VERSION=7.3
       - LARAVEL_VERSION=^7.0
-      - SYMFONY_VERSION=^5.0
+      - SYMFONY_VERSION=^4.0
       - PHPUNIT_VERSION=^8.0
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ matrix:
       - SYMFONY_VERSION=^4.0
       - PHPUNIT_VERSION=^8.0
     - env:
+      - PHP_VERSION=7.2
+      - LARAVEL_VERSION=^7.0
+      - SYMFONY_VERSION=^5.0
+      - PHPUNIT_VERSION=^8.0
+    - env:
       - PHP_VERSION=7.3
       - LARAVEL_VERSION=5.5.*
       - SYMFONY_VERSION=^3.0
@@ -71,6 +76,11 @@ matrix:
       - PHP_VERSION=7.3
       - LARAVEL_VERSION=^6.0
       - SYMFONY_VERSION=^4.0
+      - PHPUNIT_VERSION=^8.0
+    - env:
+      - PHP_VERSION=7.3
+      - LARAVEL_VERSION=^7.0
+      - SYMFONY_VERSION=^5.0
       - PHPUNIT_VERSION=^8.0
 
 

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "keywords": ["laravel", "framework", "UPS", "Laravel UPS Api", "Laravel-Ups-Api", "Pierre Tondereau", "Ptondereau"],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-    "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0",
-    "gabrielbull/ups-api": "^0.7.6"
+    "illuminate/contracts": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+    "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+    "gabrielbull/ups-api": "^0.7.14"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "keywords": ["laravel", "framework", "UPS", "Laravel UPS Api", "Laravel-Ups-Api", "Pierre Tondereau", "Ptondereau"],
   "require": {
     "php": "^7.1.3",
-    "illuminate/contracts": "^5.5|^6.0",
-    "illuminate/support": "^5.5|^6.0",
+    "illuminate/contracts": "^5.5|^6.0|^7.0",
+    "illuminate/support": "^5.5|^6.0|^7.0",
     "gabrielbull/ups-api": "^0.8"
   },
   "require-dev": {


### PR DESCRIPTION
This pull request introduces illuminate/contracts and illuminate/support at versions ^7.0 in order to support Laravel 7 which was released in March of 2020.