### PR TITLE
Support Laravel 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: PHP ${{ matrix.php }}; Laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         exclude:
           - php: '8.1'
             laravel: '11'
+          - php: '8.1'
+            laravel: '12'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]
-        laravel: [ '10', '11' ]
+        laravel: [ '10', '11', '12' ]
         exclude:
           - php: '8.1'
             laravel: '11'
@@ -46,6 +46,14 @@ jobs:
           max_attempts: 5
           command: composer require "laravel/framework:11.*" --no-update --no-interaction
         if: "matrix.laravel == '11'"
+
+      - name: Select Laravel 12
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require "laravel/framework:12.*" --no-update --no-interaction
+        if: "matrix.laravel == '12'"
 
       - name: Install PHP Dependencies
         uses: nick-invision/retry@v1

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "keywords": ["laravel", "framework", "UPS", "Laravel UPS Api", "Laravel-Ups-Api", "Pierre Tondereau", "Ptondereau"],
   "require": {
     "php": "^8.1 || ^8.2 || ^8.3",
-    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
-    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
     "gabrielbull/ups-api": "^1.2.2 || ^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require-dev": {
     "graham-campbell/analyzer": "^4.1",
     "graham-campbell/testbench": "^6.1",
-    "phpunit/phpunit": "^10.5.20"
+    "phpunit/phpunit": "^10.5.20|^11.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Adding support for Laravel 12.

To use this pre-merge, you can add the following to the repositories section of your `composer.json`

```
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/tobytwigger/Laravel-UPS-Api.git"
        }
    ]
}
```

Then update your dependency constraint to reference this branch:

```
{
    "require": {
        "ptondereau/laravel-ups-api": "dev-laravel-12",
    }
}
```