### PR TITLE
Support Laravel 13 and PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,27 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
-        laravel: [ '10', '11', '12' ]
+        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        laravel: [ '10', '11', '12', '13' ]
         exclude:
           - php: '8.1'
             laravel: '11'
           - php: '8.1'
             laravel: '12'
+          - php: '8.1'
+            laravel: '13'
+          - php: '8.2'
+            laravel: '13'
+          - php: '8.4'
+            laravel: '10'
+          - php: '8.5'
+            laravel: '10'
+          - php: '8.5'
+            laravel: '11'
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,36 +43,13 @@ jobs:
       - name: Setup Problem Matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Select Laravel 10
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "laravel/framework:10.*" --no-update --no-interaction
-        if: "matrix.laravel == '10'"
-
-      - name: Select Laravel 11
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "laravel/framework:11.*" --no-update --no-interaction
-        if: "matrix.laravel == '11'"
-
-      - name: Select Laravel 12
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "laravel/framework:12.*" --no-update --no-interaction
-        if: "matrix.laravel == '12'"
+      - name: Select Laravel ${{ matrix.laravel }}
+        run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-update --no-interaction
 
       - name: Install PHP Dependencies
-        uses: nick-invision/retry@v1
+        uses: ramsey/composer-install@v4
         with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --no-interaction --no-progress
+          dependency-versions: highest
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 composer.lock
 .phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Laravel UPS Api
 =================
 
-## For Laravel 10 and 11
+## For Laravel 10 to 13
 
 <p align="center">
-<a href="https://github.com/ptondereau/Laravel-UPS-Api/actions?query=workflow%3ATests"><img src="https://img.shields.io/github/workflow/status/ptondereau/Laravel-UPS-Api/Tests?label=Tests&style=flat-square" alt="Build Status"/></a>
+<a href="https://github.com/ptondereau/Laravel-UPS-Api/actions?query=workflow%3ATests"><img src="https://img.shields.io/github/actions/workflow/status/ptondereau/Laravel-UPS-Api/test.yml?branch=master&label=Tests&style=flat-square" alt="Build Status"/></a>
 <a href="https://github.styleci.io/repos/54156171"><img src="https://github.styleci.io/repos/54156171/shield" alt="StyleCI Status"/></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square" alt="Software License"/></a>
 <a href="https://packagist.org/packages/ptondereau/laravel-ups-api"><img src="https://img.shields.io/packagist/dt/ptondereau/laravel-ups-api?style=flat-square" alt="Packagist Downloads"/></a>

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,14 @@
   "description": "A small Laravel's wrapper for the PHP UPS API library",
   "keywords": ["laravel", "framework", "UPS", "Laravel UPS Api", "Laravel-Ups-Api", "Pierre Tondereau", "Ptondereau"],
   "require": {
-    "php": "^8.1 || ^8.2 || ^8.3",
-    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
-    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+    "php": "^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
+    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
+    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
     "gabrielbull/ups-api": "^1.2.2 || ^2.0"
   },
   "require-dev": {
-    "graham-campbell/analyzer": "^4.1",
-    "graham-campbell/testbench": "^6.1",
-    "phpunit/phpunit": "^10.5.20|^11.0"
+    "graham-campbell/testbench": "^6.3",
+    "phpunit/phpunit": "^10.5.20 || ^11.0 || ^12.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Adds Laravel 13 and PHP 8.4/8.5 support, same additive approach as #33.

- composer: illuminate/* allow `^13.0`, php constraint covers 8.1-8.5, testbench `^6.3`, PHPUnit 12 allowed, unused `graham-campbell/analyzer` removed
- CI: matrix is now PHP 8.1-8.5 x Laravel 10-13, `actions/checkout@v6`, and `ramsey/composer-install@v4` replaces the retry-wrapped composer update
- Lumen integration untouched