### PR TITLE
Add PHPStan static analysis at level 10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 * text=auto
 
+/phpstan export-ignore
+/phpstan.neon.dist export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,26 @@ jobs:
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit
+
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@v4
+        with:
+          dependency-versions: highest
+
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan analyse --memory-limit=512M --error-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 composer.lock
 .phpunit.result.cache
 .phpunit.cache
+phpstan.neon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributions are welcome, and are accepted via pull requests. Please review the
 ## Guidelines
 
 * Please follow the [PSR-12 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) and [PHP-FIG Naming Conventions](https://github.com/php-fig/fig-standards/blob/master/bylaws/002-psr-naming-conventions.md).
-* Ensure that the current tests pass, and if you've added something new, add the tests where relevant.
+* Ensure that the current tests and static analysis pass, and if you've added something new, add the tests where relevant.
 * Remember that we follow [SemVer](http://semver.org). If you are changing the behaviour, or the public api, you may need to update the docs.
 * Send a coherent commit history, making sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash](http://git-scm.com/book/en/Git-Tools-Rewriting-History) them before submitting.
 * You may also need to [rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) to avoid merge conflicts.
@@ -29,4 +29,12 @@ $ vendor/bin/phpunit
 
 If the test suite passes on your local machine you should be good to go.
 
-When you make a pull request, the tests will automatically be run on multiple php versions.
+## Running Static Analysis
+
+The codebase is analysed with [PHPStan](https://phpstan.org) at level 10:
+
+```bash
+$ composer phpstan
+```
+
+When you make a pull request, the tests will automatically be run on multiple php versions, and static analysis runs in its own CI job.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   },
   "require-dev": {
     "graham-campbell/testbench": "^6.3",
-    "phpunit/phpunit": "^10.5.20 || ^11.0 || ^12.0"
+    "phpunit/phpunit": "^10.5.20 || ^11.0 || ^12.0",
+    "phpstan/phpstan": "^2.2"
   },
   "autoload": {
     "psr-4": {
@@ -31,6 +32,10 @@
   ],
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "scripts": {
+    "phpstan": "phpstan analyse --memory-limit=512M",
+    "test": "phpunit"
+  },
   "extra": {
     "laravel": {
       "providers": [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+    level: 10
+    paths:
+        - config
+        - src
+        - tests
+    scanFiles:
+        - phpstan/LumenApplication.php

--- a/phpstan/LumenApplication.php
+++ b/phpstan/LumenApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Lumen;
+
+use Illuminate\Container\Container;
+
+/**
+ * Minimal symbol definition for PHPStan only. Lumen cannot be installed as a
+ * dev dependency because laravel/lumen-framework conflicts with the Laravel
+ * versions tested in CI, yet the Lumen branch in UpsApiServiceProvider is a
+ * deliberate support commitment.
+ */
+class Application extends Container
+{
+    public function configure(string $name): void
+    {
+    }
+}

--- a/src/Facades/UpsAddressValidation.php
+++ b/src/Facades/UpsAddressValidation.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the UpsAddressValidation facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\AddressValidation
  */
 class UpsAddressValidation extends Facade
 {

--- a/src/Facades/UpsLocator.php
+++ b/src/Facades/UpsLocator.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the Locator facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\Locator
  */
 class UpsLocator extends Facade
 {

--- a/src/Facades/UpsQuantumView.php
+++ b/src/Facades/UpsQuantumView.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the QuantumView facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\QuantumView
  */
 class UpsQuantumView extends Facade
 {

--- a/src/Facades/UpsRate.php
+++ b/src/Facades/UpsRate.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the Rate facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\Rate
  */
 class UpsRate extends Facade
 {

--- a/src/Facades/UpsRateTimeInTransit.php
+++ b/src/Facades/UpsRateTimeInTransit.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the RateTimeInTransit facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\RateTimeInTransit
  */
 class UpsRateTimeInTransit extends Facade
 {

--- a/src/Facades/UpsShipping.php
+++ b/src/Facades/UpsShipping.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the Shipping facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\Shipping
  */
 class UpsShipping extends Facade
 {

--- a/src/Facades/UpsSimpleAddressValidation.php
+++ b/src/Facades/UpsSimpleAddressValidation.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the UpsSimpleAddressValidation facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\SimpleAddressValidation
  */
 class UpsSimpleAddressValidation extends Facade
 {

--- a/src/Facades/UpsTimeInTransit.php
+++ b/src/Facades/UpsTimeInTransit.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the TimeInTransit facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\TimeInTransit
  */
 class UpsTimeInTransit extends Facade
 {

--- a/src/Facades/UpsTracking.php
+++ b/src/Facades/UpsTracking.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the Tracking facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\Tracking
  */
 class UpsTracking extends Facade
 {

--- a/src/Facades/UpsTradeability.php
+++ b/src/Facades/UpsTradeability.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * This is the Tradeability facade class.
  *
  * @author Pierre Tondereau <pierre.tondereau@gmail.com>
+ *
+ * @mixin \Ups\Tradeability
  */
 class UpsTradeability extends Facade
 {

--- a/src/UpsApiServiceProvider.php
+++ b/src/UpsApiServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace Ptondereau\LaravelUpsApi;
 
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
+use Psr\Log\LoggerInterface;
 use Ups\AddressValidation;
 use Ups\Locator;
 use Ups\QuantumView;
@@ -45,7 +47,7 @@ class UpsApiServiceProvider extends ServiceProvider
 
     protected function setupConfig(): void
     {
-        $source = realpath(__DIR__.'/../config/ups.php');
+        $source = (string) realpath(__DIR__.'/../config/ups.php');
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
             $this->publishes([$source => config_path('ups.php')]);
         } elseif ($this->app instanceof LumenApplication) {
@@ -57,7 +59,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerAddressValidation(): void
     {
         $this->app->singleton('ups.address-validation', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new AddressValidation(
                 $config['access_key'],
@@ -65,7 +67,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -73,7 +75,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerSimpleAddressValidation(): void
     {
         $this->app->singleton('ups.simple-address-validation', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new SimpleAddressValidation(
                 $config['access_key'],
@@ -81,7 +83,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -89,7 +91,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerQuantumView(): void
     {
         $this->app->singleton('ups.quantum-view', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new QuantumView(
                 $config['access_key'],
@@ -97,7 +99,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -105,7 +107,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerTracking(): void
     {
         $this->app->singleton('ups.tracking', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new Tracking(
                 $config['access_key'],
@@ -113,7 +115,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -121,14 +123,14 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerRate(): void
     {
         $this->app->singleton('ups.rate', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new Rate(
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
                 $config['sandbox'],
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -136,7 +138,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerTimeInTransit(): void
     {
         $this->app->singleton('ups.time-in-transit', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new TimeInTransit(
                 $config['access_key'],
@@ -144,7 +146,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -152,7 +154,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerLocator(): void
     {
         $this->app->singleton('ups.locator', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new Locator(
                 $config['access_key'],
@@ -160,7 +162,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -168,7 +170,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerTradeability(): void
     {
         $this->app->singleton('ups.tradeability', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new Tradeability(
                 $config['access_key'],
@@ -176,7 +178,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -184,7 +186,7 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerShipping(): void
     {
         $this->app->singleton('ups.shipping', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new Shipping(
                 $config['access_key'],
@@ -192,7 +194,7 @@ class UpsApiServiceProvider extends ServiceProvider
                 $config['password'],
                 $config['sandbox'],
                 null,
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
@@ -200,18 +202,43 @@ class UpsApiServiceProvider extends ServiceProvider
     protected function registerRateTimeInTransit(): void
     {
         $this->app->singleton('ups.ratetimeintransit', function (Container $app) {
-            $config = $app->config->get('ups');
+            $config = $this->upsConfig($app);
 
             return new RateTimeInTransit(
                 $config['access_key'],
                 $config['user_id'],
                 $config['password'],
                 $config['sandbox'],
-                $app->make('log')
+                $this->logger($app)
             );
         });
     }
 
+    /**
+     * @return array{access_key: string|null, user_id: string|null, password: string|null, sandbox: bool}
+     */
+    protected function upsConfig(Container $app): array
+    {
+        /** @var Repository $repository */
+        $repository = $app->make('config');
+
+        /** @var array{access_key: string|null, user_id: string|null, password: string|null, sandbox: bool} $config */
+        $config = $repository->get('ups');
+
+        return $config;
+    }
+
+    protected function logger(Container $app): LoggerInterface
+    {
+        /** @var LoggerInterface $logger */
+        $logger = $app->make('log');
+
+        return $logger;
+    }
+
+    /**
+     * @return list<string>
+     */
     public function provides(): array
     {
         return [

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -11,22 +11,22 @@ use Illuminate\Support\Facades\Config;
  */
 class ConfigTest extends TestCase
 {
-    public function testAccessKeyConfig()
+    public function testAccessKeyConfig(): void
     {
         $this->assertEquals(Config::get('ups.access_key'), 'test');
     }
 
-    public function testUserIdConfig()
+    public function testUserIdConfig(): void
     {
         $this->assertEquals(Config::get('ups.user_id'), 'test');
     }
 
-    public function testPasswordConfig()
+    public function testPasswordConfig(): void
     {
         $this->assertEquals(Config::get('ups.password'), 'test');
     }
 
-    public function testSandboxConfig()
+    public function testSandboxConfig(): void
     {
         $this->assertTrue(Config::get('ups.sandbox'));
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -23,52 +23,52 @@ class ServiceProviderTest extends TestCase
 {
     use ServiceProviderTrait;
 
-    public function testAddressValidationIsInjectable()
+    public function testAddressValidationIsInjectable(): void
     {
         $this->assertIsInjectable(AddressValidation::class);
     }
 
-    public function testSimpleAddressValidationIsInjectable()
+    public function testSimpleAddressValidationIsInjectable(): void
     {
         $this->assertIsInjectable(SimpleAddressValidation::class);
     }
 
-    public function testQuantumViewIsInjectable()
+    public function testQuantumViewIsInjectable(): void
     {
         $this->assertIsInjectable(QuantumView::class);
     }
 
-    public function testTrackingIsInjectable()
+    public function testTrackingIsInjectable(): void
     {
         $this->assertIsInjectable(Tracking::class);
     }
 
-    public function testRateIsInjectable()
+    public function testRateIsInjectable(): void
     {
         $this->assertIsInjectable(Rate::class);
     }
 
-    public function testTimeInTransitIsInjectable()
+    public function testTimeInTransitIsInjectable(): void
     {
         $this->assertIsInjectable(TimeInTransit::class);
     }
 
-    public function testLocatorIsInjectable()
+    public function testLocatorIsInjectable(): void
     {
         $this->assertIsInjectable(Locator::class);
     }
 
-    public function testTradeabilityIsInjectable()
+    public function testTradeabilityIsInjectable(): void
     {
         $this->assertIsInjectable(Tradeability::class);
     }
 
-    public function testShippingIsInjectable()
+    public function testShippingIsInjectable(): void
     {
         $this->assertIsInjectable(Shipping::class);
     }
 
-    public function testRateTimeInTransitIsInjectable()
+    public function testRateTimeInTransitIsInjectable(): void
     {
         $this->assertIsInjectable(RateTimeInTransit::class);
     }


### PR DESCRIPTION
This adds PHPStan at level 10 over `config`, `src` and `tests`, with a dedicated CI job running on PHP 8.4 with highest dependencies.

The service provider now resolves the config repository and logger through two typed helpers instead of the magic `$app->config` property access, which concentrates the untyped container boundary in one place. The Lumen code path is preserved and stays analyzable through a `scanFiles` stub, since `laravel/lumen-framework` cannot be installed next to the Laravel versions tested in CI. Each facade declares `@mixin` to its `Ups\*` root class, so consumers running PHPStan or PhpStorm get real return types and argument checks on facade calls instead of `mixed` through `__callStatic`.

Larastan was considered and skipped on purpose: larastan 3.x requires illuminate ^11.44 with PHPStan 2, while larastan 2.x needs PHPStan 1, which would conflict on the Laravel 10 matrix legs. Plain PHPStan has no illuminate dependencies and resolves on every leg. It can be revisited once Laravel 10 support is dropped.
